### PR TITLE
fix: backport `assimp` PR 6283

### DIFF
--- a/cadmesh/CMakeLists.txt
+++ b/cadmesh/CMakeLists.txt
@@ -59,6 +59,7 @@ else()
         SOURCE_DIR ${PROJECT_SOURCE_DIR}/external/assimp
         GIT_REPOSITORY https://github.com/assimp/assimp.git
         GIT_TAG v5.4.3
+        PATCH_COMMAND git apply ${PROJECT_SOURCE_DIR}/v5.4.3.patch
         CMAKE_ARGS -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}
     )
     include_directories(${PROJECT_BINARY_DIR}/include/assimp/include)

--- a/cadmesh/v5.4.3.patch
+++ b/cadmesh/v5.4.3.patch
@@ -1,0 +1,42 @@
+diff --git i/code/AssetLib/X3D/X3DGeoHelper.cpp w/code/AssetLib/X3D/X3DGeoHelper.cpp
+index 1c962a460..03316a081 100644
+--- i/code/AssetLib/X3D/X3DGeoHelper.cpp
++++ w/code/AssetLib/X3D/X3DGeoHelper.cpp
+@@ -128,13 +128,22 @@ void X3DGeoHelper::rect_parallel_epiped(const aiVector3D &pSize, std::list<aiVec
+ 
+ #undef MESH_RectParallelepiped_CREATE_VERT
+ 
++//////////////////////////////////////////////////////////////////////////////////
++// PATCH:
++// backport of https://github.com/assimp/assimp/pull/6283
++//////////////////////////////////////////////////////////////////////////////////
++
++static constexpr int InvalidIndex = -1;
++
+ void X3DGeoHelper::coordIdx_str2faces_arr(const std::vector<int32_t> &pCoordIdx, std::vector<aiFace> &pFaces, unsigned int &pPrimitiveTypes) {
+     std::vector<int32_t> f_data(pCoordIdx);
+     std::vector<unsigned int> inds;
+     unsigned int prim_type = 0;
+ 
+-    if (f_data.back() != (-1)) {
+-        f_data.push_back(-1);
++    if (!f_data.empty()) {
++        if (f_data.back() != InvalidIndex) {
++            f_data.push_back(InvalidIndex);
++        }
+     }
+ 
+     // reserve average size.
+@@ -191,8 +200,10 @@ mg_m_err:
+ void X3DGeoHelper::coordIdx_str2lines_arr(const std::vector<int32_t> &pCoordIdx, std::vector<aiFace> &pFaces) {
+     std::vector<int32_t> f_data(pCoordIdx);
+ 
+-    if (f_data.back() != (-1)) {
+-        f_data.push_back(-1);
++    if (!f_data.empty()) {
++        if (f_data.back() != InvalidIndex) {
++            f_data.push_back(InvalidIndex);
++        }
+     }
+ 
+     // reserve average size.


### PR DESCRIPTION
apply backport of https://github.com/assimp/assimp/pull/6283

resolves `cadmesh` build errors
```
/opt/mlibrary/cadmesh/external/assimp/code/AssetLib/X3D/X3DGeoHelper.cpp: In static member function ‘static void Assimp::X3DGeoHelper::coordIdx_str2lines_arr(const std::vector<int>&, std::vector<aiFace>&)’:
/opt/mlibrary/cadmesh/external/assimp/code/AssetLib/X3D/X3DGeoHelper.cpp:194:20: error: array subscript -1 is outside array bounds of ‘int [2305843009213693951]’ [-Werror=array-bounds=]
  194 |     if (f_data.back() != (-1)) {
      |         ~~~~~~~~~~~^~
In file included from /usr/include/c++/15.2.1/x86_64-pc-linux-gnu/bits/c++allocator.h:33,
                 from /usr/include/c++/15.2.1/bits/allocator.h:46,
                 from /usr/include/c++/15.2.1/string:45,
                 from /opt/mlibrary/cadmesh/external/assimp/include/assimp/types.h:78,
                 from /opt/mlibrary/cadmesh/external/assimp/code/AssetLib/X3D/X3DGeoHelper.h:6,
                 from /opt/mlibrary/cadmesh/external/assimp/code/AssetLib/X3D/X3DGeoHelper.cpp:1:
In member function ‘_Tp* std::__new_allocator<_Tp>::allocate(size_type, const void*) [with _Tp = int]’,
    inlined from ‘static _Tp* std::allocator_traits<std::allocator<_CharT> >::allocate(allocator_type&, size_type) [with _Tp = int]’ at /usr/include/c++/15.2.1/bits/alloc_traits.h:614:28,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::pointer std::_Vector_base<_Tp, _Alloc>::_M_allocate(std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15.2.1/bits/stl_vector.h:387:33,
    inlined from ‘void std::_Vector_base<_Tp, _Alloc>::_M_create_storage(std::size_t) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15.2.1/bits/stl_vector.h:405:44,
    inlined from ‘std::_Vector_base<_Tp, _Alloc>::_Vector_base(std::size_t, const allocator_type&) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15.2.1/bits/stl_vector.h:341:26,
    inlined from ‘std::vector<_Tp, _Alloc>::vector(const std::vector<_Tp, _Alloc>&) [with _Tp = int; _Alloc = std::allocator<int>]’ at /usr/include/c++/15.2.1/bits/stl_vector.h:633:61,
    inlined from ‘static void Assimp::X3DGeoHelper::coordIdx_str2lines_arr(const std::vector<int>&, std::vector<aiFace>&)’ at /opt/mlibrary/cadmesh/external/assimp/code/AssetLib/X3D/X3DGeoHelper.cpp:192:42:
/usr/include/c++/15.2.1/bits/new_allocator.h:151:73: note: at offset -4 into object of size [4, 9223372036854775804] allocated by ‘operator new’
  151 |         return static_cast<_Tp*>(_GLIBCXX_OPERATOR_NEW(__n * sizeof(_Tp)));
      |                                                                         ^
cc1plus: all warnings being treated as errors
make[5]: *** [code/CMakeFiles/assimp.dir/build.make:2571: code/CMakeFiles/assimp.dir/AssetLib/X3D/X3DGeoHelper.cpp.o] Error 1
make[5]: *** Waiting for unfinished jobs....
make[4]: *** [CMakeFiles/Makefile2:184: code/CMakeFiles/assimp.dir/all] Error 2
make[3]: *** [Makefile:136: all] Error 2
make[2]: *** [CMakeFiles/assimp_external.dir/build.make:86: assimp_external-prefix/src/assimp_external-stamp/assimp_external-build] Error 2
make[1]: *** [CMakeFiles/Makefile2:147: CMakeFiles/assimp_external.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```